### PR TITLE
test for x-dead-letter-exchange and x-dead-letter-routing-key errors

### DIFF
--- a/t/008_queue_declare.t
+++ b/t/008_queue_declare.t
@@ -30,9 +30,6 @@ is($message_count, 0, "got message count back");
 is($consumer_count, 0, "got consumer count back");
 
 
-my $original_queue = 'test1';
-my $messageTTL = 10;
-
 my $queue_options = {
         'x-dead-letter-exchange'    => 'amq.direct',
         'x-dead-letter-routing-key' => $expect_qn,

--- a/t/008_queue_declare.t
+++ b/t/008_queue_declare.t
@@ -1,4 +1,4 @@
-use Test::More tests => 8;
+use Test::More tests => 9;
 use strict;
 use warnings;
 
@@ -28,4 +28,25 @@ is($@, '', "queue_declare");
 is($queuename, $expect_qn, "queue_declare -> $queuename = $expect_qn");
 is($message_count, 0, "got message count back");
 is($consumer_count, 0, "got consumer count back");
+
+
+my $original_queue = 'test1';
+my $messageTTL = 10;
+
+my $queue_options = {
+        'x-dead-letter-exchange'    => 'amq.direct',
+        'x-dead-letter-routing-key' => $expect_qn,
+        'x-message-ttl'             => 10000,
+        'x-expires'                 => 20000,
+        };
+my $delay_queue = eval {
+	$mq->queue_declare(1,
+        	"",
+        	{ auto_delete => 1, },
+        	$queue_options,
+        	);
+};
+
+is($@, '', "queue_declare");
+
 1;


### PR DESCRIPTION
Hello,

Somewhere between 0.005 and 0.007 (we upgraded from 5->7), we have been unable to create queues with x-dead-letter-exchange and x-dead-letter-routing-key args... we get the error 

Declaring queue: server channel error 406, message: PRECONDITION_FAILED - invalid type 'binary' for arg 'x-dead-letter-exchange' in queue 'amq.gen-OTZiCGpYgi81jt4Y93sU7w' in vhost '/'

I verified it still exists in 0.010000 (latest on cpan).

I've been digging into some this evening, but I wanted to send you a commit with the test fail in case you had some insight to the problem, being more directly familiar with the module internals.

Thanks,
Dan.
